### PR TITLE
Fix: Exclude examples directory from version control

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 .git/
 node_modules/
 npm-debug.log
+examples/


### PR DESCRIPTION
To keep the repository clean and focused on the source code, this commit updates .gitignore and .npmignore to exclude the examples directory. The examples directory contains real-world usage examples of the library, which are not necessary for the package functionality but useful for developers. By excluding these files from version control, we minimize the package size and streamline the development process.